### PR TITLE
Fix GZIP saving. Add -g argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Command-line:
 <table><tr><td><strong>Argument</strong></td><td><strong>Result</strong></td></tr>
 <tr><td>-d <i>file1</i> <i>file2</i></td><td>Decode <i>file1</i> (in true NBT format), and write the results (in text format) to <i>file2</i></td></tr>
 <tr><td>-c <i>file1</i> <i>file2</i></td><td>Encode <i>file1</i> (in text format), and write the results (in true NBT format) to <i>file2</i></td></tr>
-<tr><td>-m <i>file</i></td><td>Read <i>file</i> for editing in CLI-NBT</td></tr></table>
+<tr><td>-m <i>file</i></td><td>Read <i>file</i> for editing in CLI-NBT</td></tr>
+<tr><td>-g <i>file</i></td><td>Load <i>file</i> with gzip decompression</td></tr></table>
 
 Text language:
 &lt;tag-type&gt;:"&lt;name&gt;"=&lt;value&gt;;<br/>

--- a/src/com/gn32/apps/clinbt/Main.java
+++ b/src/com/gn32/apps/clinbt/Main.java
@@ -64,6 +64,14 @@ public class Main {
                         currentTag = nbt.getMain();
                         break;
                     }
+                    case "-g": {
+                    	if(args.length < 2) {
+                            System.out.println("Must specify a file to read after -g!");
+                            System.exit(0);
+                    	}
+                        println("Reading compressed file '" + args[1] + "'");
+                        load(args[1]);
+                    }
                     default:
                         println("Reading file '" + args[0] + "'");
                         load(args[0]);
@@ -259,11 +267,14 @@ public class Main {
     
     static void save(String arg) throws IOException {
         try {
-            if(arg.startsWith("-g ")) {
-                nbt.writeNBT(Utils.setResourceAsGZIPStream(arg.substring(3)));
-            } else {
-                nbt.writeNBT(Utils.setResourceAsStream(arg));
-            }
+        	DataOutputStream out;
+            if(arg.startsWith("-g "))
+                out = Utils.setResourceAsGZIPStream(arg.substring(3));
+            else
+                out = Utils.setResourceAsStream(arg);
+            nbt.writeNBT(out);
+            out.flush();
+            out.close();
         } catch(NBTException nbte) {
             println("Error: " + nbte.getMessage());
         }
@@ -271,11 +282,13 @@ public class Main {
     
     static void load(String arg) throws IOException {
         try {
-            if(arg.startsWith("-g ")) {
-                nbt = NBT.readNBT(Utils.getResourceAsGZIPStream(arg.substring(3)));
-            } else {
-                nbt = NBT.readNBT(Utils.getResourceAsStream(arg));
-            }
+        	DataInputStream in;
+            if(arg.startsWith("-g "))
+                in = Utils.getResourceAsGZIPStream(arg.substring(3));
+            else
+                in = Utils.getResourceAsStream(arg);
+            nbt = NBT.readNBT(in);
+            in.close();
             currentTag = nbt.getMain();
         } catch(NBTException nbte) {
             println("Error: " + nbte.getMessage());


### PR DESCRIPTION
I really like the work you've done here. I noticed, though, that saving with GZIP compression didn't work, as the compressed stream wasn't being flushed/closed (resulting in the file giving end of stream while decompressing). I also added the -g argument, since I find myself more often messing with compressed files in MC world folders.
